### PR TITLE
✨ feat: useDelayFlag 생성

### DIFF
--- a/src/hooks/useDelayFlag.ts
+++ b/src/hooks/useDelayFlag.ts
@@ -4,23 +4,33 @@ export const useDelayFlag = (flag: boolean, delay: number = 1000): boolean => {
   const startTimeRef = useRef(0);
   const [delayFlag, setDelayFlag] = useState(false);
 
+  const initializeFlag = () => {
+    startTimeRef.current = Date.now();
+    setDelayFlag(true);
+  };
+
+  const resetFlag = () => {
+    setDelayFlag(false);
+  };
+
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | null = null;
 
-    if (flag) {
-      startTimeRef.current = Date.now();
-      setDelayFlag(true);
-    } else if (startTimeRef.current) {
+    const delayFlag = () => {
       const elapsedTime = Date.now() - startTimeRef.current;
       const remainingTime = delay - elapsedTime;
 
       if (remainingTime > 0) {
-        timeoutId = setTimeout(() => {
-          setDelayFlag(false);
-        }, remainingTime);
+        timeoutId = setTimeout(resetFlag, remainingTime);
       } else {
-        setDelayFlag(false);
+        resetFlag();
       }
+    };
+
+    if (flag) {
+      initializeFlag();
+    } else if (startTimeRef.current) {
+      delayFlag();
     }
 
     return () => {

--- a/src/hooks/useDelayFlag.ts
+++ b/src/hooks/useDelayFlag.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
+import { PositiveInteger } from '../types/number';
 
-export const useDelayFlag = (
+export const useDelayFlag = <T extends number>(
   flag: boolean,
-  delayTime: number = 1000
+  delayTime?: PositiveInteger<T>
 ): boolean => {
   const startTimeRef = useRef(0);
   const [delayFlag, setDelayFlag] = useState(false);
@@ -21,7 +22,7 @@ export const useDelayFlag = (
 
     const delayFlag = () => {
       const elapsedTime = Date.now() - startTimeRef.current;
-      const remainingTime = delayTime - elapsedTime;
+      const remainingTime = (delayTime || 1000) - elapsedTime;
 
       if (remainingTime > 0) {
         timeoutId = setTimeout(resetFlag, remainingTime);

--- a/src/hooks/useDelayFlag.ts
+++ b/src/hooks/useDelayFlag.ts
@@ -39,6 +39,7 @@ export const useDelayFlag = (
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [flag]);
 
   return delayFlag;

--- a/src/hooks/useDelayFlag.ts
+++ b/src/hooks/useDelayFlag.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useRef } from 'react';
 
-export const useDelayFlag = (flag: boolean, delay: number = 1000): boolean => {
+export const useDelayFlag = (
+  flag: boolean,
+  delayTime: number = 1000
+): boolean => {
   const startTimeRef = useRef(0);
   const [delayFlag, setDelayFlag] = useState(false);
 
@@ -18,7 +21,7 @@ export const useDelayFlag = (flag: boolean, delay: number = 1000): boolean => {
 
     const delayFlag = () => {
       const elapsedTime = Date.now() - startTimeRef.current;
-      const remainingTime = delay - elapsedTime;
+      const remainingTime = delayTime - elapsedTime;
 
       if (remainingTime > 0) {
         timeoutId = setTimeout(resetFlag, remainingTime);

--- a/src/hooks/useDelayFlag.ts
+++ b/src/hooks/useDelayFlag.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useRef } from 'react';
+
+export const useDelayFlag = (flag: boolean, delay: number = 1000): boolean => {
+  const startTimeRef = useRef(0);
+  const [delayFlag, setDelayFlag] = useState(false);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | null = null;
+
+    if (flag) {
+      startTimeRef.current = Date.now();
+      setDelayFlag(true);
+    } else if (startTimeRef.current) {
+      const elapsedTime = Date.now() - startTimeRef.current;
+      const remainingTime = delay - elapsedTime;
+
+      if (remainingTime > 0) {
+        timeoutId = setTimeout(() => {
+          setDelayFlag(false);
+        }, remainingTime);
+      } else {
+        setDelayFlag(false);
+      }
+    }
+
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [flag]);
+
+  return delayFlag;
+};

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -1,0 +1,6 @@
+export type PositiveInteger<T extends number> = `${T}` extends
+  | `-${string}`
+  | `${string}.${string}`
+  | '0'
+  ? never
+  : T;


### PR DESCRIPTION
## 👾 Pull Request
- 작업명: useDelayFlag
<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [[react hooks] useDelayFlag](https://use-react-hooks.atlassian.net/browse/URH-10)
<!-- (버그픽스, 기능 업데이트, 신규) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규

### Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 인자로 받은 플래그(페칭 또는 로딩)를 일정 시간 이상 지연시킵니다.
- 데이터 페칭 시간이 0.1초만에 종료될 경우 사용자에게 로딩 UI를 보여주면 플리커 현상이 발생하는데, 이를 개선할 수 있는 훅입니다.
- 이 훅을 통해 반환된 플래그는 기본적으로 1초(1000ms)간 지속됩니다.

### 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->
```ts
const isDelayLoading = useDelayFlag(isLoading);
// or
const isTwoSecondDelayLoading = useDelayFlag(isLoading, 2000);
```
