### PR TITLE
[URH-23] useConfirm 신규

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "use-react-hooks",
       "version": "0.0.0",
       "dependencies": {
+        "@headlessui/react": "^2.1.2",
         "async-wave": "^1.8.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1246,6 +1247,72 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.4.tgz",
+      "integrity": "sha512-a4IowK4QkXl4SCWTGUR0INAfEOX3wtsYw3rKK5InQEHMGObkR8Xk44qYQD9P4r6HHw0iIfK6GUKECmY8sTkqRA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.4"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.7.tgz",
+      "integrity": "sha512-wmVfPG5o2xnKDU4jx/m4w5qva9FWHcnZ8BvzEe90D/RpwsJaTAVYPEPdQ8sbr/N8zZTAHlZUTQdqg8ZUbzHmng==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.4"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.19.tgz",
+      "integrity": "sha512-Jk6zITdjjIvjO/VdQFvpRaD3qPwOHH6AoDHxjhpy+oK4KFgaSP871HYWUAPdnLmx1gQ+w/pB312co3tVml+BXA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.1",
+        "@floating-ui/utils": "^0.2.4",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.4.tgz",
+      "integrity": "sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA=="
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.2.tgz",
+      "integrity": "sha512-Kb3hgk9gRNRcTZktBrKdHhF3xFhYkca1Rk6e1/im2ENf83dgN54orMW0uSKTXFnUpZOUFZ+wcY05LlipwgZIFQ==",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.17.1",
+        "@react-aria/interactions": "^3.21.3",
+        "@tanstack/react-virtual": "^3.8.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18",
+        "react-dom": "^18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -1446,6 +1513,83 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
+      "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
+      "dependencies": {
+        "@react-aria/interactions": "^3.21.3",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.21.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
+      "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.4",
+        "@react-aria/utils": "^3.24.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
+      "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
+      "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.4",
+        "@react-stately/utils": "^3.10.1",
+        "@react-types/shared": "^3.23.1",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
+      "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
+      "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1668,6 +1812,14 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
+      "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -1678,6 +1830,31 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.8.3.tgz",
+      "integrity": "sha512-9ICwbDUUzN99CJIGc373i8NLoj6zFTKI2Hlcmo0+lCSAhPQ5mxq4dGOMKmLYoEFyHcGQ64Bd6ZVbnPpM6lNK5w==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.8.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.8.3.tgz",
+      "integrity": "sha512-vd2A2TnM5lbnWZnHi9B+L2gPtkSeOtJOAw358JqokIH1+v2J7vUAzFVPwB/wrye12RFOurffXu33plm4uQ+JBQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -2738,6 +2915,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -6892,6 +7077,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
     "node_modules/text-extensions": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
@@ -6964,8 +7154,7 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ]
   },
   "dependencies": {
+    "@headlessui/react": "^2.1.2",
     "async-wave": "^1.8.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/src/context/ConfirmContext.tsx
+++ b/src/context/ConfirmContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useState } from 'react';
+
+interface ConfirmContext {
+  setMessage: (message: string) => void;
+  setResolve: (resolve: (value: boolean) => void) => void;
+}
+
+export const ConfirmContext = createContext<ConfirmContext>({
+  setMessage() {},
+  setResolve() {},
+});
+
+export const ConfirmProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [message, setMessage] = useState<string>('');
+  const [resolve, setResolve] = useState<(value: boolean) => void>();
+
+  const onConfirm = () => {
+    resolve?.(true);
+  };
+
+  const onCancel = () => {
+    resolve?.(false);
+  };
+
+  return (
+    <ConfirmContext.Provider value={{ setMessage, setResolve }}>
+      <>
+        {children}
+        <div className="dialog">
+          <div className="dialog-content">{message}</div>
+          <div className="dialog-actions">
+            <button onClick={onCancel}>아니오</button>
+            <button onClick={onConfirm}>예</button>
+          </div>
+        </div>
+      </>
+    </ConfirmContext.Provider>
+  );
+};

--- a/src/context/ConfirmContext.tsx
+++ b/src/context/ConfirmContext.tsx
@@ -1,11 +1,15 @@
 import { createContext, useState } from 'react';
 
 interface ConfirmContext {
+  message?: string;
+  resolve?: (value: boolean) => void;
   setMessage: (message: string) => void;
   setResolve: (resolve: (value: boolean) => void) => void;
 }
 
 export const ConfirmContext = createContext<ConfirmContext>({
+  message: '',
+  resolve() {},
   setMessage() {},
   setResolve() {},
 });
@@ -15,29 +19,13 @@ export const ConfirmProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [message, setMessage] = useState<string>('');
+  const [message, setMessage] = useState<string>();
   const [resolve, setResolve] = useState<(value: boolean) => void>();
 
-  const onConfirm = () => {
-    resolve?.(true);
-  };
-
-  const onCancel = () => {
-    resolve?.(false);
-  };
-
   return (
-    <ConfirmContext.Provider value={{ setMessage, setResolve }}>
-      <>
-        {children}
-        <div className="dialog">
-          <div className="dialog-content">{message}</div>
-          <div className="dialog-actions">
-            <button onClick={onCancel}>아니오</button>
-            <button onClick={onConfirm}>예</button>
-          </div>
-        </div>
-      </>
+    <ConfirmContext.Provider
+      value={{ message, resolve, setMessage, setResolve }}>
+      {children}
     </ConfirmContext.Provider>
   );
 };

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import { ConfirmContext } from '../context/ConfirmContext';
+import { ConfirmContext as context } from '../context/ConfirmContext';
 
 const useConfirm = () => {
-  const { setMessage, setResolve } = useContext(ConfirmContext);
+  const { setMessage, setResolve } = useContext(context);
 
   const confirm = (message: string) => {
     setMessage(message);

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,10 +1,21 @@
 import { useContext } from 'react';
 import { ConfirmContext as context } from '../context/ConfirmContext';
 
+/**
+ * 컨펌 다이얼로그를 구현할 때 사용하는 훅.
+ *
+ * @returns {string} message: 컨펌 메시지. confirm() 함수에 전달된 값을 그대로 반환.
+ * @returns {boolean} isOpen: 컨펌 다이얼로그 open/close 상태를 제어할 수 있는 값. confirm() 함수 실행 단계에서 업데이트된 message 값을 체크하여 상태를 결정.
+ * @returns {function} confirm: 컨펌 로직을 실행하는 비동기 함수. 컨펌 다이얼로그를 열고 사용자의 컨펌 여부를 반환.
+ * @returns {function} onConfirm: 컨펌 다이얼로그를 컨펌하는 함수.
+ * @returns {function} onCancel: 컨펌 다이얼로그를 취소하는 함수.
+ *
+ * @description
+ * - 이 훅은 브라우저의 confirm() 메서드와 동일하게 작동합니다.
+ * - 훅에서 파생된 상태를 활용해 컨펌 다이얼로그 컨텍스트를 관리할 수 있습니다.
+ */
 const useConfirm = () => {
   const { message, resolve, setMessage, setResolve } = useContext(context);
-
-  const isOpen = !!message;
 
   const confirm = (message: string) => {
     setMessage(message);
@@ -23,7 +34,7 @@ const useConfirm = () => {
     setMessage('');
   };
 
-  return { message, isOpen, confirm, onConfirm, onCancel };
+  return { message, isOpen: !!message, confirm, onConfirm, onCancel };
 };
 
 export default useConfirm;

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -2,17 +2,28 @@ import { useContext } from 'react';
 import { ConfirmContext as context } from '../context/ConfirmContext';
 
 const useConfirm = () => {
-  const { setMessage, setResolve } = useContext(context);
+  const { message, resolve, setMessage, setResolve } = useContext(context);
+
+  const isOpen = !!message;
 
   const confirm = (message: string) => {
     setMessage(message);
-
     return new Promise<boolean>((resolve) => {
       setResolve(() => resolve);
     });
   };
 
-  return confirm;
+  const onConfirm = () => {
+    resolve?.(true);
+    setMessage('');
+  };
+
+  const onCancel = () => {
+    resolve?.(false);
+    setMessage('');
+  };
+
+  return { message, isOpen, confirm, onConfirm, onCancel };
 };
 
 export default useConfirm;

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,18 @@
+import { useContext } from 'react';
+import { ConfirmContext } from '../context/ConfirmContext';
+
+const useConfirm = () => {
+  const { setMessage, setResolve } = useContext(ConfirmContext);
+
+  const confirm = (message: string) => {
+    setMessage(message);
+
+    return new Promise<boolean>((resolve) => {
+      setResolve(() => resolve);
+    });
+  };
+
+  return confirm;
+};
+
+export default useConfirm;


### PR DESCRIPTION
## 👾 Pull Request
- 작업명: useConfirm
- 티켓: [[react hooks] useConfirm](https://use-react-hooks.atlassian.net/browse/URH-23)
- 상태: 신규

### 1️⃣ Spec
- 브라우저 `confirm()` 메서드와 동일한 기능을 제공하는 훅
- async/await 비동기 로직으로 작동
- `message`, `isOpen`, `confirm`, `onConfirm`, `onCancel`를 외부에 제공

### 2️⃣ 변경 사항
- 변경 사항 없음

### 3️⃣ 예시 코드
```jsx
// main.tsx
<ConfirmProvider>
  <App />
</ConfirmProvider>
```

```jsx
// App.tsx
function App() {
  const { confirm, isOpen, message, onConfirm, onCancel } = useConfirm();

  const handleConfirm = async () => {
    if (await confirm('message')) {
      console.log('Confirmed');
    } else {
      console.log('Canceled');
    }
  };

  return (
    <>
      <Button onClick={handleConfirm}>Confirm</Button>

      <Dialog open={isOpen}>
        <DialogContent>
          {message}
          <Button onClick={onConfirm}>Confirm</Button>
          <Button onClick={onCancel}>Cancel</Button>
        </DialogContent>
      </Dialog>
    </>
  )
}
```

- 처음에 DialogContext 까지 제작해 사용자에겐 `confirm()` 메서드만 제공하려고 했던 계획이 변경되었습니다.
- 사용자가 Dialog를 직접 정의하고 useConfirm에서 제공하는 메서드를 매핑하는 것이 사용성이 더 좋다고 판단했습니다.