### PR TITLE
[URH-22] useOutsideInteraction 신규

### DIFF
--- a/src/hooks/useOutsideInteraction.ts
+++ b/src/hooks/useOutsideInteraction.ts
@@ -1,0 +1,57 @@
+import { useCallback, MutableRefObject, useEffect, useRef } from 'react';
+
+type EventType =
+  | 'mousedown'
+  | 'mouseup'
+  | 'touchstart'
+  | 'touchend'
+  | 'keydown';
+
+interface UseOutsideInteractionProps {
+  handleOutsideInteraction: () => void;
+  events?: EventType[];
+}
+
+const defaultEvents: EventType[] = ['mousedown', 'touchstart', 'keydown'];
+
+const useOutsideInteraction = ({
+  handleOutsideInteraction,
+  events = defaultEvents,
+}: UseOutsideInteractionProps): MutableRefObject<HTMLElement | null> => {
+  const ref = useRef<HTMLElement | null>(null);
+
+  const handleEvent = useCallback(
+    (event: Event) => {
+      if (event instanceof KeyboardEvent) {
+        if (event.key === 'Escape') {
+          handleOutsideInteraction();
+          return;
+        }
+      }
+
+      const target = event.target as Node | null;
+      if (!target) return;
+
+      if (ref.current && !ref.current.contains(target)) {
+        handleOutsideInteraction();
+      }
+    },
+    [handleOutsideInteraction]
+  );
+
+  useEffect(() => {
+    if (events.length === 0) return;
+
+    events.forEach((event) => document.addEventListener(event, handleEvent));
+
+    return () => {
+      events.forEach((event) =>
+        document.removeEventListener(event, handleEvent)
+      );
+    };
+  }, [handleEvent, events]);
+
+  return ref;
+};
+
+export default useOutsideInteraction;

--- a/src/hooks/useOutsideInteraction.ts
+++ b/src/hooks/useOutsideInteraction.ts
@@ -14,6 +14,17 @@ interface UseOutsideInteractionProps {
 
 const defaultEvents: EventType[] = ['mousedown', 'touchstart', 'keydown'];
 
+/**
+ * 지정된 element 외부의 interaction을 감지하는 hook
+ * 마우스 클릭, 터치, 키보드 이벤트(Escape 키)를 처리할 수 있습니다.
+ *
+ * @param {Object} props - hook props
+ * @param {() => void} props.handleOutsideInteraction - 외부 interaction 발생 시 실행될 콜백 함수
+ * @param {EventType[]} [props.events] - 감지할 이벤트 (default :['mousedown', 'touchstart', 'keydown'])
+ *
+ * @returns {React.MutableRefObject<HTMLElement | null>} element에 연결할 ref 객체
+ */
+
 const useOutsideInteraction = ({
   handleOutsideInteraction,
   events = defaultEvents,

--- a/src/hooks/useOutsideInteraction.ts
+++ b/src/hooks/useOutsideInteraction.ts
@@ -1,4 +1,4 @@
-import { useCallback, MutableRefObject, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, RefObject } from 'react';
 
 type EventType =
   | 'mousedown'
@@ -22,14 +22,14 @@ const defaultEvents: EventType[] = ['mousedown', 'touchstart', 'keydown'];
  * @param {() => void} props.handleOutsideInteraction - 외부 interaction 발생 시 실행될 콜백 함수
  * @param {EventType[]} [props.events] - 감지할 이벤트 (default :['mousedown', 'touchstart', 'keydown'])
  *
- * @returns {React.MutableRefObject<HTMLElement | null>} element에 연결할 ref 객체
+ * @returns {React.RefObject<HTMLElement>} element에 연결할 ref 객체
  */
 
 const useOutsideInteraction = ({
   handleOutsideInteraction,
   events = defaultEvents,
-}: UseOutsideInteractionProps): MutableRefObject<HTMLElement | null> => {
-  const ref = useRef<HTMLElement | null>(null);
+}: UseOutsideInteractionProps): RefObject<HTMLElement> => {
+  const ref = useRef<HTMLElement>(null);
 
   const handleEvent = useCallback(
     (event: Event) => {


### PR DESCRIPTION
## 👾 Pull Request
- 작업명:
<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [useOnClickOutside](https://use-react-hooks.atlassian.net/browse/URH-22)
<!-- (버그픽스, 기능 업데이트, 신규) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규

### 1️⃣ Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 특정 엘리먼트의 외부 영역을 터치, 클릭하는 경우 인자로 전달받은 함수 실행
- 키보드 사용자를 위한 접근성 개선 - 모달에 주로 사용되는 hook이기 때문에 좋은 스펙이라고 생각하여 추가
  - esc 키 클릭 시 인자로 전달받은 함수 실행

### 2️⃣ 변경 사항
<!-- 스펙이 변경되거나 내부 구조가 바뀐다면 작성해주세요. -->
- 이벤트 타입이 click 뿐만 아니라 다른 타입들도 추가되며 이름을 useOutsideInteraction으로 변경
- 키보드 이벤트(esc)도 받아 처리하도록 수정

### 3️⃣ 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->
```ts
const Modal = () => {
  const [isOpen, setIsOpen] = useState(false);

  const handleOutsideInteraction = () => {
    setIsOpen(false);
  };

  const modalRef = useOutsideInteraction({ handleOutsideInteraction });

  return (
    <div>
      <button onClick={() => setIsOpen(true)}>modal open</button>

      {isOpen && (
        <div ref={modalRef}>
            <h2>모달</h2>
            <p>모달 외부를 클릭하거나 esc키를 누르면 modal close</p>
        </div>
      )}
    </div>
  );
};
```

### 4️⃣ 관련 문서 (선택 사항)
- 
-