### PR TITLE
[URH-42] useDetectInactivity 신규

### DIFF
--- a/src/hooks/useDetectInactivity.test.ts
+++ b/src/hooks/useDetectInactivity.test.ts
@@ -1,0 +1,126 @@
+import { act, renderHook } from '@testing-library/react';
+import useDetectInactivity, { isTouchDevice } from './useDetectInactivity';
+import useTimer from './useTimer';
+
+jest.mock('./useTimer');
+
+describe('useDetectInactivity', () => {
+  let startMock: jest.Mock;
+  let onInactivityMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    startMock = jest.fn();
+    onInactivityMock = jest.fn();
+    (useTimer as jest.Mock).mockImplementation((callback, time) => ({
+      start: () => {
+        startMock();
+        // 타이머 만료 후 콜백 호출
+        setTimeout(() => {
+          callback();
+        }, time);
+      },
+    }));
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  test('타이머에 설정된 시간 후에는 비활동 상태가 감지된다.', () => {
+    const { result } = renderHook(() =>
+      useDetectInactivity(5000, onInactivityMock)
+    );
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onInactivityMock).toHaveBeenCalled();
+    expect(result.current).toBe(true);
+  });
+
+  test('비활동 상태일때 onInactivity콜백은 호출되지 않는다.', () => {
+    renderHook(() => useDetectInactivity(5000, onInactivityMock));
+
+    act(() => {
+      jest.advanceTimersByTime(4500);
+    });
+
+    expect(onInactivityMock).not.toHaveBeenCalled();
+  });
+
+  test('활동(설정된 이벤트)이 감지되면 타이머는 리셋된 후 다시 실행된다.', () => {
+    const { result } = renderHook(() =>
+      useDetectInactivity(5000, onInactivityMock)
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event('keyup'));
+    });
+
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event('mousemove'));
+    });
+
+    expect(startMock).toHaveBeenCalledTimes(2);
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(onInactivityMock).toHaveBeenCalled();
+    expect(result.current).toBe(true);
+  });
+
+  test('환경에 맞게 이벤트 리스너가 추가/제거된다.', () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() =>
+      useDetectInactivity(5000, onInactivityMock)
+    );
+
+    const expectedClientEvents = isTouchDevice()
+      ? ['touchstart']
+      : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
+
+    const addedEvents = addEventListenerSpy.mock.calls.map(
+      ([event, callback]) => ({ event, callback })
+    );
+
+    expectedClientEvents.forEach((event) => {
+      expect(addedEvents.some((e) => e.event === event)).toBe(true);
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    const removedEvents = removeEventListenerSpy.mock.calls.map(
+      ([event, callback]) => ({ event, callback })
+    );
+    // 제거된 이벤트 리스트가 올바른지 확인
+    expectedClientEvents.forEach((event) => {
+      expect(removedEvents.some((e) => e.event === event)).toBe(true);
+    });
+
+    addEventListenerSpy.mockRestore();
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/src/hooks/useDetectInactivity.test.ts
+++ b/src/hooks/useDetectInactivity.test.ts
@@ -15,7 +15,6 @@ describe('useDetectInactivity', () => {
     (useTimer as jest.Mock).mockImplementation((callback, time) => ({
       start: () => {
         startMock();
-        // 타이머 만료 후 콜백 호출
         setTimeout(() => {
           callback();
         }, time);
@@ -115,7 +114,7 @@ describe('useDetectInactivity', () => {
     const removedEvents = removeEventListenerSpy.mock.calls.map(
       ([event, callback]) => ({ event, callback })
     );
-    // 제거된 이벤트 리스트가 올바른지 확인
+
     expectedClientEvents.forEach((event) => {
       expect(removedEvents.some((e) => e.event === event)).toBe(true);
     });

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -24,32 +24,24 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
     ? ['touchstart']
     : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
 
-  const handleChange = useCallback(() => {
+  const resetTimer = useCallback(() => {
     setIsInactive(false);
     start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const throttledHandleChange = throttle(handleChange, 1000);
-
-  const resetTimer = useCallback(
-    (event: Event) => {
-      throttledHandleChange(event);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
   useEffect(() => {
     start();
 
+    const throttledResetTimer = throttle(resetTimer, 5000);
+
     clientEvents.forEach((event) => {
-      window.addEventListener(event, resetTimer);
+      window.addEventListener(event, throttledResetTimer);
     });
 
     return () => {
       clientEvents.forEach((event) =>
-        window.removeEventListener(event, resetTimer)
+        window.removeEventListener(event, throttledResetTimer)
       );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 import { Fn } from '../types';
-import { throttle } from './useMousePosition';
+import { throttle } from '../utils';
 
 /**
  * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
@@ -33,6 +33,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
   useEffect(() => {
     start();
 
+    // 이벤트 리스너는 5초마다 감지
     const throttledResetTimer = throttle(resetTimer, 5000);
 
     clientEvents.forEach((event) => {

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -6,14 +6,14 @@ import { throttle } from '../utils';
 /**
  * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
  *
- * @param {number} time - 비활성 상태로 간주되기까지의 시간(밀리초). 양의 정수로 지정.
+ * @param {number} time - 비활성 상태로 간주되기까지의 시간(밀리초). 양의 정수로 지정. (최소값 5000ms)
  * @param {Fn} onInactivity - 비활성 상태가 감지되었을 때 호출되는 콜백 함수.
  *
  * @returns {boolean} - 현재 비활동 상태 여부를 나타내는 boolean 값.
  *
  * @description
  * 사용자가 정의한 시간(time) 동안 활동이 없으면 비활성 상태로 간주하고, 지정된 콜백 함수(onInactivity)를 호출합니다.
- * 해당 환경에 맞게 설정된 이벤트를 리스닝하여, 활동이 감지될 시 타이머를 리셋합니다.
+ * 해당 환경에 맞게 설정된 이벤트를 5초마다 리스닝하여, 활동이 감지될 시 타이머를 리셋합니다.
  */
 
 const useDetectInactivity = (time: number, onInactivity: Fn) => {

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 import { Fn } from '../types';
+import { throttle } from './useMousePosition';
 
 /**
  * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
@@ -23,13 +24,21 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
     ? ['touchstart']
     : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
 
-  const resetTimer = useCallback(() => {
-    if (isInactive) {
-      setIsInactive(false);
-    }
+  const handleChange = useCallback(() => {
+    setIsInactive(false);
     start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const throttledHandleChange = throttle(handleChange, 1000);
+
+  const resetTimer = useCallback(
+    (event: Event) => {
+      throttledHandleChange(event);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   useEffect(() => {
     start();

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 
+// 시간 바꾸고
+
 const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
   const [isInactive, setIsInactive] = useState(false);
   const { start } = useTimer(() => setIsInactive(true), time);
 
-  const clientEvent = ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
+  const clientEvents = isTouchDevice()
+    ? ['touchstart']
+    : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
 
   const resetTimer = useCallback(() => {
     setIsInactive(false);
@@ -16,14 +20,16 @@ const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
   useEffect(() => {
     start();
 
-    clientEvent.forEach((event) => window.addEventListener(event, resetTimer));
+    clientEvents.forEach((event) => {
+      window.addEventListener(event, resetTimer);
+    });
 
     if (isInactive) {
       onInactivity();
     }
 
     return () => {
-      clientEvent.forEach((event) =>
+      clientEvents.forEach((event) =>
         window.removeEventListener(event, resetTimer)
       );
     };
@@ -41,3 +47,10 @@ const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
 };
 
 export default useDetectInactivity;
+
+const isTouchDevice = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+};

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 import { Fn } from '../types';
-import { isClient, throttle } from '../utils';
+import { isTouchDevice, throttle } from '../utils';
 
 /**
  * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
@@ -65,10 +65,3 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
 };
 
 export default useDetectInactivity;
-
-const isTouchDevice = () => {
-  if (!isClient) {
-    return false;
-  }
-  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
-};

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import useTimer from './useTimer';
+
+const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
+  const [isInactive, setIsInactive] = useState(false);
+  const { start } = useTimer(() => setIsInactive(true), time);
+
+  const clientEvent = ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
+
+  const resetTimer = useCallback(() => {
+    setIsInactive(false);
+    start();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    start();
+
+    clientEvent.forEach((event) => window.addEventListener(event, resetTimer));
+
+    if (isInactive) {
+      onInactivity();
+    }
+
+    return () => {
+      clientEvent.forEach((event) =>
+        window.removeEventListener(event, resetTimer)
+      );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (isInactive) {
+      onInactivity();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isInactive]);
+
+  return isInactive;
+};
+
+export default useDetectInactivity;

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 import { Fn } from '../types';
-import { throttle } from '../utils';
+import { isClient, throttle } from '../utils';
 
 /**
  * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
@@ -36,7 +36,6 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
   const resetTimer = useCallback(() => {
     setIsInactive(false);
     start();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [start]);
 
   useEffect(() => {
@@ -67,8 +66,8 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
 
 export default useDetectInactivity;
 
-export const isTouchDevice = () => {
-  if (typeof window === 'undefined') {
+const isTouchDevice = () => {
+  if (!isClient) {
     return false;
   }
   return 'ontouchstart' in window || navigator.maxTouchPoints > 0;

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -25,7 +25,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
 
   if (time < MIN_THROTTLE_TIME) {
     throw new Error(
-      `The 'time' parameter must be at least ${MIN_THROTTLE_TIME}ms. The provided value was too short and has been adjusted.`
+      `'time'은 최소 ${MIN_THROTTLE_TIME}ms 이상으로 설정되어야 합니다.`
     );
   }
 

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -20,6 +20,15 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
   const [isInactive, setIsInactive] = useState(false);
   const { start } = useTimer(() => setIsInactive(true), time);
 
+  // 이벤트 리스너는 5초마다 감지
+  const MIN_THROTTLE_TIME = 5000;
+
+  if (time < MIN_THROTTLE_TIME) {
+    throw new Error(
+      `The 'time' parameter must be at least ${MIN_THROTTLE_TIME}ms. The provided value was too short and has been adjusted.`
+    );
+  }
+
   const clientEvents = isTouchDevice()
     ? ['touchstart']
     : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
@@ -33,8 +42,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
   useEffect(() => {
     start();
 
-    // 이벤트 리스너는 5초마다 감지
-    const throttledResetTimer = throttle(resetTimer, 5000);
+    const throttledResetTimer = throttle(resetTimer, MIN_THROTTLE_TIME);
 
     clientEvents.forEach((event) => {
       window.addEventListener(event, throttledResetTimer);

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -2,6 +2,19 @@ import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
 import { Fn } from '../types';
 
+/**
+ * 일정 시간(ms) 동안 활동이 없을 때 지정된 콜백 함수를 실행하는 훅.
+ *
+ * @param {number} time - 비활성 상태로 간주되기까지의 시간(밀리초). 양의 정수로 지정.
+ * @param {Fn} onInactivity - 비활성 상태가 감지되었을 때 호출되는 콜백 함수.
+ *
+ * @returns {boolean} - 현재 비활동 상태 여부를 나타내는 boolean 값.
+ *
+ * @description
+ * 사용자가 정의한 시간(time) 동안 활동이 없으면 비활성 상태로 간주하고, 지정된 콜백 함수(onInactivity)를 호출합니다.
+ * 해당 환경에 맞게 설정된 이벤트를 리스닝하여, 활동이 감지될 시 타이머를 리셋합니다.
+ */
+
 const useDetectInactivity = (time: number, onInactivity: Fn) => {
   const [isInactive, setIsInactive] = useState(false);
   const { start } = useTimer(() => setIsInactive(true), time);

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -37,7 +37,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
     setIsInactive(false);
     start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [start]);
 
   useEffect(() => {
     start();
@@ -54,7 +54,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
       );
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [resetTimer]);
 
   useEffect(() => {
     if (isInactive) {

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -55,7 +55,7 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
 
 export default useDetectInactivity;
 
-const isTouchDevice = () => {
+export const isTouchDevice = () => {
   if (typeof window === 'undefined') {
     return false;
   }

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -24,7 +24,9 @@ const useDetectInactivity = (time: number, onInactivity: Fn) => {
     : ['mousemove', 'keydown', 'click', 'dblclick', 'scroll'];
 
   const resetTimer = useCallback(() => {
-    setIsInactive(false);
+    if (isInactive) {
+      setIsInactive(false);
+    }
     start();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/hooks/useDetectInactivity.ts
+++ b/src/hooks/useDetectInactivity.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import useTimer from './useTimer';
+import { Fn } from '../types';
 
-// 시간 바꾸고
-
-const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
+const useDetectInactivity = (time: number, onInactivity: Fn) => {
   const [isInactive, setIsInactive] = useState(false);
   const { start } = useTimer(() => setIsInactive(true), time);
 
@@ -24,10 +23,6 @@ const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
       window.addEventListener(event, resetTimer);
     });
 
-    if (isInactive) {
-      onInactivity();
-    }
-
     return () => {
       clientEvents.forEach((event) =>
         window.removeEventListener(event, resetTimer)
@@ -40,8 +35,7 @@ const useDetectInactivity = (time = 10000, onInactivity = () => {}) => {
     if (isInactive) {
       onInactivity();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isInactive]);
+  }, [isInactive, onInactivity]);
 
   return isInactive;
 };

--- a/src/hooks/useMousePosition.ts
+++ b/src/hooks/useMousePosition.ts
@@ -160,7 +160,7 @@ const useMousePosition = ({
 
 export default useMousePosition;
 
-const throttle = <T extends Event>(
+export const throttle = <T extends Event>(
   callbackFn: (event: T) => void,
   delayTime: number
 ) => {

--- a/src/hooks/useMousePosition.ts
+++ b/src/hooks/useMousePosition.ts
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { throttle } from '../utils';
 
 interface MousePosOptions {
   delayTime?: number;
@@ -159,21 +160,6 @@ const useMousePosition = ({
 };
 
 export default useMousePosition;
-
-export const throttle = <T extends Event>(
-  callbackFn: (event: T) => void,
-  delayTime: number
-) => {
-  let lastTime = 0;
-
-  return (event: T) => {
-    const now = Date.now();
-    if (now - lastTime >= delayTime) {
-      lastTime = now;
-      callbackFn(event);
-    }
-  };
-};
 
 const animationFrameHandler = <T extends Event>(
   callbackFn: (event: T) => void

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,3 @@
 export type Fn = () => void;
+
+export type GenericFn<T extends unknown[]> = (...args: T) => void;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { delayExecution, type CancelToken } from './delayExecution';
+export { throttle } from './throttle';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { delayExecution, type CancelToken } from './delayExecution';
 export { throttle } from './throttle';
+export { isClient } from './isClient';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { delayExecution, type CancelToken } from './delayExecution';
 export { throttle } from './throttle';
 export { isClient } from './isClient';
+export { isTouchDevice } from './isTouchDevice';

--- a/src/utils/isClient.ts
+++ b/src/utils/isClient.ts
@@ -1,0 +1,1 @@
+export const isClient = typeof window !== 'undefined';

--- a/src/utils/isTouchDevice.ts
+++ b/src/utils/isTouchDevice.ts
@@ -1,0 +1,8 @@
+import { isClient } from './isClient';
+
+export const isTouchDevice = () => {
+  if (!isClient) {
+    return false;
+  }
+  return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+};

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,14 +1,18 @@
-export const throttle = <T extends Event>(
-  callbackFn: (event: T) => void,
+type GenericCallback<T extends unknown[]> = (...args: T) => void;
+
+export const throttle = <T extends unknown[]>(
+  callbackFn: GenericCallback<T>,
   delayTime: number
 ) => {
   let lastTime = 0;
 
-  return (event: T) => {
+  const throttledFunction = (...args: T) => {
     const now = Date.now();
     if (now - lastTime >= delayTime) {
       lastTime = now;
-      callbackFn(event);
+      callbackFn(...args);
     }
   };
+
+  return throttledFunction;
 };

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,0 +1,14 @@
+export const throttle = <T extends Event>(
+  callbackFn: (event: T) => void,
+  delayTime: number
+) => {
+  let lastTime = 0;
+
+  return (event: T) => {
+    const now = Date.now();
+    if (now - lastTime >= delayTime) {
+      lastTime = now;
+      callbackFn(event);
+    }
+  };
+};

--- a/src/utils/throttle.ts
+++ b/src/utils/throttle.ts
@@ -1,7 +1,7 @@
-type GenericCallback<T extends unknown[]> = (...args: T) => void;
+import { GenericFn } from '../types';
 
 export const throttle = <T extends unknown[]>(
-  callbackFn: GenericCallback<T>,
+  callbackFn: GenericFn<T>,
   delayTime: number
 ) => {
   let lastTime = 0;


### PR DESCRIPTION
## 👾 Pull Request
<!-- PR 제목 예시: [티켓 번호] {작업명} {상태}-->

<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [useDetectInactivity 신규](https://use-react-hooks.atlassian.net/browse/URH-42?atlOrigin=eyJpIjoiNTEwNjAzZTA1MWMwNDY3MWE0ZmRmYzIzMzA5N2RjNzEiLCJwIjoiaiJ9)

<!-- (신규, 기능 업데이트, 버그 픽스, 리팩토링) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규

### 1️⃣ Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 지정한 시간(ms) 동안 활동이 없을 때 전달한 콜백 함수를 실행하는 훅
- 설정할 수 있는 시간은 최소 5000ms 이상(EventListener 감지 주기= 5000ms)
- 사용자의 디바이스가 터치 기능을 지원하는지를 판단(isTouchDevice)하여 이벤트 리스너를 설정
- (선택) 반환값으로 비활성상태를 나타내는 boolean값을 받을 수 있음

### 2️⃣ 변경 사항
<!-- 스펙이 변경되거나 내부 구조가 바뀐다면 작성해주세요. -->
- useMousePosition에서 사용된 throttle을 utils로 분리 및 index.ts에 추가

### 3️⃣ 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->

#### 1. 반환값이 없는 경우
- 임의의 설정시간 5분
```ts
function Component() {
  function noActivity() {
    alert('지정된 시간 동안 사용자의 움직임이 감지되지 않았습니다 ');
  }
  useDetectInactivity(300000, noActivity);
}
export default Component;
```

#### 2. 반환값이 있는 경우
- 임의의 설정시간 5분
```ts
function Component() {
  function noActivity() {
    alert('지정된 시간 동안 사용자의 움직임이 감지되지 않았습니다 ');
  }

  const isInactivity = useDetectInactivity(300000, noActivity);

  return <div>{isInactivity ? <h1>비활성상태입니다</h1> : <h1>일반</h1>}</div>;
}

export default Component;
```

### 4️⃣ 관련 문서 (선택 사항)
- 없음


---

+) `isTouchDevice` 라는 함수를 작성해서 **현재 상태가 터치기능을 지원하는지 판단**하여 상태에따라 등록되는 이벤트를 분리할 수 있도록 했는데, 이 함수가 다른 훅에서도 쓰일 가능성이 있다면 util안으로 분리하고 싶습니다.