### PR TITLE
[URH-24] useScrollY 신규

### DIFF
--- a/src/hooks/useScrollY.test.ts
+++ b/src/hooks/useScrollY.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from '@testing-library/react';
+import useScrollY from './useScrollY';
+
+global.scrollTo = jest.fn();
+
+describe('useScrollY', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('스크롤 이벤트 발생 시 500ms 딜레이 후 로컬스토리지에 스크롤 위치가 저장된다.', () => {
+    renderHook(() => useScrollY());
+
+    const pathname = encodeURIComponent(window.location.pathname);
+
+    Object.defineProperty(window, 'scrollY', { value: 100, writable: true });
+
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+      jest.advanceTimersByTime(500);
+    });
+
+    const savedScrollY = localStorage.getItem(pathname);
+    expect(savedScrollY).toBe('100');
+  });
+
+  test('moveTrigger() 함수가 실행되면 로컬스토리지에 저장되어있던 스크롤 위치로 이동한다.', () => {
+    const pathname = encodeURIComponent(window.location.pathname);
+    localStorage.setItem(pathname, '100');
+
+    const { result } = renderHook(() => useScrollY());
+
+    act(() => {
+      result.current.moveTrigger();
+    });
+
+    expect(global.scrollTo).toHaveBeenCalledWith(0, 100);
+  });
+});

--- a/src/hooks/useScrollY.ts
+++ b/src/hooks/useScrollY.ts
@@ -7,7 +7,7 @@ const useScrollY = (): { moveTrigger: Fn } => {
   const isClient = typeof window !== 'undefined';
 
   const [savedScrollY, setSavedScrollY] = useLocalStorage(
-    encodeURIComponent(window.location.pathname),
+    encodeURIComponent(window?.location?.pathname),
     0
   );
 

--- a/src/hooks/useScrollY.ts
+++ b/src/hooks/useScrollY.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect } from 'react';
+import { Fn } from '../types';
+import { debounce } from '../utils/debounce';
+import useLocalStorage from './useLocalStorage';
+
+const useScrollY = (): { moveTrigger: Fn } => {
+  const isClient = typeof window !== 'undefined';
+
+  const [savedScrollY, setSavedScrollY] = useLocalStorage(
+    encodeURIComponent(window.location.pathname),
+    0
+  );
+
+  const saveScrollY = () => {
+    setSavedScrollY(window.scrollY);
+  };
+
+  const handleScroll = debounce(() => {
+    saveScrollY();
+  }, 500);
+
+  const moveTrigger = useCallback(() => {
+    if (!isClient) return;
+    window.scrollTo(0, savedScrollY);
+  }, [isClient, savedScrollY]);
+
+  useEffect(() => {
+    if (!isClient) return;
+    window.addEventListener('scroll', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isClient]);
+
+  return { moveTrigger };
+};
+
+export default useScrollY;

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+export const debounce = <T extends (...args: unknown[]) => void>(
+  func: T,
+  delay: number
+) => {
+  let timeoutId: NodeJS.Timeout | null = null;
+  return (...args: Parameters<T>) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func(...args), delay);
+  };
+};


### PR DESCRIPTION
## 👾 Pull Request

- 티켓: [useScrollY 신규](https://use-react-hooks.atlassian.net/browse/URH-24)
- 상태: 신규

### 1️⃣ Spec
- 현재 페이지(pathname)의 세로 스크롤 값을 로컬 스토리지에 저장하는 훅
- 다른 페이지로 이동했다가 다시 돌아왔을 때 `trigger()` 함수를 실행시켜 저장된 스크롤 위치로 이동할 수 있음

### 2️⃣ 변경 사항
- 없음

### 3️⃣ 예시 코드
```jsx
function App() {
  const { moveTrigger } = useScrollY();

  useEffect(() => {
    moveTrigger();
  }, []);

  return (
    <div>
      <h1>USE-REACT-HOOKS</h1>
    </div>
  );
}

export default App;
```