### PR TITLE
[URH-51] useClipboard 신규

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ const config: JestConfigWithTsJest = {
   moduleNameMapper: {
     '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
   },
+  setupFiles: ['jest-canvas-mock'],
   setupFilesAfterEnv: ['./jest.setup.ts'],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "husky": "^9.1.4",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
+        "jest-canvas-mock": "^2.5.2",
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^15.2.7",
         "prettier": "^3.3.2",
@@ -4728,6 +4729,12 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -7106,6 +7113,16 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "node_modules/jest-changed-files": {
@@ -9501,6 +9518,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -15429,6 +15461,12 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -17097,6 +17135,16 @@
         "@jest/types": "^29.6.3",
         "import-local": "^3.0.2",
         "jest-cli": "^29.7.0"
+      }
+    },
+    "jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
       }
     },
     "jest-changed-files": {
@@ -18899,6 +18947,23 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "husky": "^9.1.4",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
+    "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.2",

--- a/src/hooks/useClipboard.test.ts
+++ b/src/hooks/useClipboard.test.ts
@@ -1,10 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import useClipboard from './useClipboard';
 
-Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
-  value: jest.fn(),
-});
-
 Object.assign(navigator, {
   clipboard: {
     writeText: jest.fn(),
@@ -16,43 +12,63 @@ describe('useClipboard', () => {
   beforeEach(() => {
     const { result } = renderHook(() => useClipboard());
     result.current.copied = false;
+    jest.useFakeTimers();
   });
 
-  test('copyText() 함수를 호출하면 클립보드에 텍스트가 저장된다.', () => {
-    const { result } = renderHook(() => useClipboard());
-    const { copied, copyText } = result.current;
-
-    const text = 'Text';
+  test('copyText() 함수를 호출하면 클립보드에 텍스트가 저장된다.', async () => {
     const spy = jest.spyOn(navigator.clipboard, 'writeText');
+    const { result } = renderHook(() => useClipboard());
+    const { copyText } = result.current;
+    const text = 'Text';
 
     act(() => {
       copyText(text);
     });
 
     expect(spy).toHaveBeenCalledWith(text);
-
-    waitFor(() => {
-      expect(copied).toBe(true);
+    await waitFor(() => {
+      expect(result.current.copied).toBe(true);
     });
   });
 
-  test('copyImg() 함수를 호출하면 클립보드에 이미지가 저장된다.', () => {
-    const { result } = renderHook(() => useClipboard());
-    const { copied, copyImg } = result.current;
+  // test('copyImg() 함수를 호출하면 클립보드에 이미지가 저장된다.', async () => {
+  //   const spy = jest.spyOn(navigator.clipboard, 'write');
+  //   const { result } = renderHook(() => useClipboard());
+  //   const { copyImg } = result.current;
+  //   const path =
+  //     'https://avatars.githubusercontent.com/u/173591906?s=400&u=4083b40d445144ec5f214b5d2d7efbd5471f3f97&v=4';
 
-    const path =
-      'https://avatars.githubusercontent.com/u/173591906?s=400&u=4083b40d445144ec5f214b5d2d7efbd5471f3f97&v=4';
-    const spy = jest.spyOn(navigator.clipboard, 'write');
+  //   act(() => {
+  //     copyImg(path);
+  //   });
+
+  //   expect(spy).toHaveBeenCalled();
+  //   await waitFor(() => {
+  //     expect(result.current.copied).toBe(true);
+  //   });
+  // });
+
+  test('copied 상태가 true로 변경된 이후 5초가 지나면 다시 false로 변경된다.', async () => {
+    const spy = jest.spyOn(navigator.clipboard, 'writeText');
+    const { result } = renderHook(() => useClipboard());
+    const { copyText } = result.current;
+    const text = 'Text';
 
     act(() => {
-      copyImg(path);
+      copyText(text);
     });
 
-    waitFor(() => {
-      expect(spy).toHaveBeenCalled();
-      expect(copied).toBe(true);
+    expect(spy).toHaveBeenCalledWith(text);
+    await waitFor(() => {
+      expect(result.current.copied).toBe(true);
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.copied).toBe(false);
     });
   });
-
-  test('copied 상태가 true로 변경된 이후 5초가 지나면 다시 false로 변경된다.', () => {});
 });

--- a/src/hooks/useClipboard.test.ts
+++ b/src/hooks/useClipboard.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import useClipboard from './useClipboard';
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: jest.fn(),
+});
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn(),
+    write: jest.fn(),
+  },
+});
+
+describe('useClipboard', () => {
+  beforeEach(() => {
+    const { result } = renderHook(() => useClipboard());
+    result.current.copied = false;
+  });
+
+  test('copyText() 함수를 호출하면 클립보드에 텍스트가 저장된다.', () => {
+    const { result } = renderHook(() => useClipboard());
+    const { copied, copyText } = result.current;
+
+    const text = 'Text';
+    const spy = jest.spyOn(navigator.clipboard, 'writeText');
+
+    act(() => {
+      copyText(text);
+    });
+
+    expect(spy).toHaveBeenCalledWith(text);
+
+    waitFor(() => {
+      expect(copied).toBe(true);
+    });
+  });
+
+  test('copyImg() 함수를 호출하면 클립보드에 이미지가 저장된다.', () => {
+    const { result } = renderHook(() => useClipboard());
+    const { copied, copyImg } = result.current;
+
+    const path =
+      'https://avatars.githubusercontent.com/u/173591906?s=400&u=4083b40d445144ec5f214b5d2d7efbd5471f3f97&v=4';
+    const spy = jest.spyOn(navigator.clipboard, 'write');
+
+    act(() => {
+      copyImg(path);
+    });
+
+    waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+      expect(copied).toBe(true);
+    });
+  });
+
+  test('copied 상태가 true로 변경된 이후 5초가 지나면 다시 false로 변경된다.', () => {});
+});

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+
+const useClipboard = () => {
+  const [copied, setCopied] = useState(false);
+
+  if (!navigator.clipboard) {
+    throw new Error('Clipboard API not supported.');
+  }
+
+  const copyText = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch (error) {
+      console.error(error);
+      throw new Error(`Failed to save text to clipboard.`);
+    }
+  };
+
+  return { copied, copyText };
+};
+
+export default useClipboard;

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { imgToBlob } from '../utils';
 
-interface Props {
+interface UseClipboardProps {
   resetTime?: number;
 }
 
-interface Returns {
+interface UseClipboardReturns {
   copied: boolean;
   copyText: (text: string) => void;
   copyImg: (path: string) => void;
@@ -24,7 +24,9 @@ interface Returns {
  * @description
  * 클립보드 API가 지원되지 않는 경우 에러를 발생시킵니다.
  */
-const useClipboard = ({ resetTime = 5000 }: Props = {}): Returns => {
+const useClipboard = ({
+  resetTime = 5000,
+}: UseClipboardProps = {}): UseClipboardReturns => {
   const [copied, setCopied] = useState(false);
 
   if (!navigator.clipboard) {
@@ -42,13 +44,13 @@ const useClipboard = ({ resetTime = 5000 }: Props = {}): Returns => {
     }
   };
 
-  const copyText = (text: string) => {
-    handleCopy(() => navigator.clipboard.writeText(text));
+  const copyText = async (text: string) => {
+    await handleCopy(() => navigator.clipboard.writeText(text));
   };
 
   const copyImg = async (path: string) => {
     const imgBlob = await imgToBlob(path);
-    handleCopy(() =>
+    await handleCopy(() =>
       navigator.clipboard.write([new ClipboardItem({ 'image/png': imgBlob })])
     );
   };

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { imgToBlob } from '../utils';
 
 const useClipboard = () => {
   const [copied, setCopied] = useState(false);
@@ -17,7 +18,28 @@ const useClipboard = () => {
     }
   };
 
-  return { copied, copyText };
+  const copyImg = (path: string) => {
+    imgToBlob(path, async (imgBlob) => {
+      if (!imgBlob) return;
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({ 'image/png': imgBlob }),
+        ]);
+        setCopied(true);
+      } catch (error) {
+        console.error(error);
+        throw new Error(`Failed to save image to clipboard.`);
+      }
+    });
+  };
+
+  useEffect(() => {
+    return () => {
+      setCopied(false);
+    };
+  }, []);
+
+  return { copied, copyText, copyImg };
 };
 
 export default useClipboard;

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -18,28 +18,28 @@ const useClipboard = () => {
     throw new Error('Clipboard API not supported.');
   }
 
-  const copyText = async (text: string) => {
+  const handleCopy = async (copy: () => Promise<void>) => {
+    setCopied(false);
     try {
-      await navigator.clipboard.writeText(text);
+      await copy();
       setCopied(true);
     } catch (error) {
+      setCopied(false);
       console.error(error);
-      throw new Error(`Failed to save text to clipboard.`);
+      throw new Error(`Failed to save to clipboard.`);
     }
+  };
+
+  const copyText = (text: string) => {
+    handleCopy(() => navigator.clipboard.writeText(text));
   };
 
   const copyImg = (path: string) => {
     imgToBlob(path, async (imgBlob) => {
       if (!imgBlob) return;
-      try {
-        await navigator.clipboard.write([
-          new ClipboardItem({ 'image/png': imgBlob }),
-        ]);
-        setCopied(true);
-      } catch (error) {
-        console.error(error);
-        throw new Error(`Failed to save image to clipboard.`);
-      }
+      handleCopy(() =>
+        navigator.clipboard.write([new ClipboardItem({ 'image/png': imgBlob })])
+      );
     });
   };
 

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -34,13 +34,11 @@ const useClipboard = () => {
     handleCopy(() => navigator.clipboard.writeText(text));
   };
 
-  const copyImg = (path: string) => {
-    imgToBlob(path, async (imgBlob) => {
-      if (!imgBlob) return;
-      handleCopy(() =>
-        navigator.clipboard.write([new ClipboardItem({ 'image/png': imgBlob })])
-      );
-    });
+  const copyImg = async (path: string) => {
+    const imgBlob = await imgToBlob(path);
+    handleCopy(() =>
+      navigator.clipboard.write([new ClipboardItem({ 'image/png': imgBlob })])
+    );
   };
 
   useEffect(() => {

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,17 +1,30 @@
 import { useState, useEffect } from 'react';
 import { imgToBlob } from '../utils';
 
+interface Props {
+  resetTime?: number;
+}
+
+interface Returns {
+  copied: boolean;
+  copyText: (text: string) => void;
+  copyImg: (path: string) => void;
+}
+
 /**
  * 클립보드에 텍스트나 이미지를 복사하는 커스텀 훅
  *
- * @returns {boolean} `copied`: 복사 작업의 성공 여부를 나타내는 플래그
- * @returns {(string) => Promise<void>} `copyText`: 텍스트를 클립보드에 복사하는 비동기 함수
- * @returns {(string) => void} `copyImg`: 주어진 경로의 이미지를 클립보드에 복사하는 함수
+ * @param {number} [resetTime=5000] - 복사 작업이 완료된 후 플래그를 리셋할 시간(ms)
+ *
+ * @returns
+ * - `copied`: 복사 작업의 성공 여부를 나타내는 플래그
+ * - `copyText`: 텍스트를 클립보드에 복사하는 비동기 함수
+ * - `copyImg`: 주어진 경로의 이미지를 클립보드에 복사하는 함수
  *
  * @description
  * 클립보드 API가 지원되지 않는 경우 에러를 발생시킵니다.
  */
-const useClipboard = () => {
+const useClipboard = ({ resetTime = 5000 }: Props): Returns => {
   const [copied, setCopied] = useState(false);
 
   if (!navigator.clipboard) {
@@ -45,9 +58,10 @@ const useClipboard = () => {
     if (copied) {
       const timer = setTimeout(() => {
         setCopied(false);
-      }, 5000);
+      }, resetTime);
       return () => clearTimeout(timer);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [copied]);
 
   return { copied, copyText, copyImg };

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -44,10 +44,13 @@ const useClipboard = () => {
   };
 
   useEffect(() => {
-    return () => {
-      setCopied(false);
-    };
-  }, []);
+    if (copied) {
+      const timer = setTimeout(() => {
+        setCopied(false);
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
 
   return { copied, copyText, copyImg };
 };

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -37,7 +37,6 @@ const useClipboard = ({ resetTime = 5000 }: Props): Returns => {
       await copy();
       setCopied(true);
     } catch (error) {
-      setCopied(false);
       console.error(error);
       throw new Error(`Failed to save to clipboard.`);
     }

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -24,7 +24,7 @@ interface Returns {
  * @description
  * 클립보드 API가 지원되지 않는 경우 에러를 발생시킵니다.
  */
-const useClipboard = ({ resetTime = 5000 }: Props): Returns => {
+const useClipboard = ({ resetTime = 5000 }: Props = {}): Returns => {
   const [copied, setCopied] = useState(false);
 
   if (!navigator.clipboard) {

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,6 +1,16 @@
 import { useState, useEffect } from 'react';
 import { imgToBlob } from '../utils';
 
+/**
+ * 클립보드에 텍스트나 이미지를 복사하는 커스텀 훅
+ *
+ * @returns {boolean} `copied`: 복사 작업의 성공 여부를 나타내는 플래그
+ * @returns {(string) => Promise<void>} `copyText`: 텍스트를 클립보드에 복사하는 비동기 함수
+ * @returns {(string) => void} `copyImg`: 주어진 경로의 이미지를 클립보드에 복사하는 함수
+ *
+ * @description
+ * 클립보드 API가 지원되지 않는 경우 에러를 발생시킵니다.
+ */
 const useClipboard = () => {
   const [copied, setCopied] = useState(false);
 

--- a/src/utils/imgToBlob.ts
+++ b/src/utils/imgToBlob.ts
@@ -3,6 +3,7 @@ const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d');
 
 export const imgToBlob = (path: string, func: (blob: Blob | null) => void) => {
+  img.crossOrigin = 'Anonymous';
   img.onload = function () {
     if (this instanceof HTMLImageElement) {
       canvas.width = this.naturalWidth;

--- a/src/utils/imgToBlob.ts
+++ b/src/utils/imgToBlob.ts
@@ -1,0 +1,17 @@
+const img = new Image();
+const canvas = document.createElement('canvas');
+const ctx = canvas.getContext('2d');
+
+export const imgToBlob = (path: string, func: (blob: Blob | null) => void) => {
+  img.onload = function () {
+    if (this instanceof HTMLImageElement) {
+      canvas.width = this.naturalWidth;
+      canvas.height = this.naturalHeight;
+      ctx?.drawImage(this, 0, 0);
+      canvas.toBlob((blob) => {
+        func(blob);
+      }, 'image/png');
+    }
+  };
+  img.src = path;
+};

--- a/src/utils/imgToBlob.ts
+++ b/src/utils/imgToBlob.ts
@@ -2,17 +2,21 @@ const img = new Image();
 const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d');
 
-export const imgToBlob = (path: string, func: (blob: Blob | null) => void) => {
-  img.crossOrigin = 'Anonymous';
-  img.onload = function () {
-    if (this instanceof HTMLImageElement) {
-      canvas.width = this.naturalWidth;
-      canvas.height = this.naturalHeight;
-      ctx?.drawImage(this, 0, 0);
-      canvas.toBlob((blob) => {
-        func(blob);
-      }, 'image/png');
-    }
-  };
-  img.src = path;
+export const imgToBlob = (path: string): Promise<Blob> => {
+  return new Promise((resolve, reject) => {
+    img.crossOrigin = 'Anonymous';
+    img.onload = function () {
+      if (this instanceof HTMLImageElement) {
+        canvas.width = this.naturalWidth;
+        canvas.height = this.naturalHeight;
+        ctx?.drawImage(this, 0, 0);
+        canvas.toBlob((blob) => {
+          blob
+            ? resolve(blob)
+            : reject(new Error('Failed to convert image to blob'));
+        }, 'image/png');
+      }
+    };
+    img.src = path;
+  });
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export { delayExecution, type CancelToken } from './delayExecution';
 export { throttle } from './throttle';
 export { isClient } from './isClient';
 export { isTouchDevice } from './isTouchDevice';
+export { imgToBlob } from './imgToBlob';


### PR DESCRIPTION
## 👾 Pull Request

- 티켓: [useClipboard 신규](https://use-react-hooks.atlassian.net/browse/URH-51)
- 상태: 신규 (+테스트 코드 작성 중)

### 1️⃣ Spec
- 텍스트와 이미지를 클립보드에 복사하는 훅
- 복사된 상태를 제공하여 토스트 팝업과 함께 사용할 때 유용

### 2️⃣ 변경 사항
- 없음

### 3️⃣ 예시 코드
```tsx
const { copied, copyText, copyImg } = useClipboard();

return (
  <div>
    <button 
      onClick={() => copyText('Hello World')}>
      Copy Text
    </button>
    <button
      onClick={() => copyImg('https://avatars.githubusercontent.com/u/173591906?s=200&v=4')}>
      Copy Image
    </button>
    <p> {copied ? 'Copied!' : ''}</p>
  </div>
);
```

### 4️⃣ 관련 문서 (선택 사항)
- [MDN Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API)