### PR TITLE
[URH-50] useEventListener 신규

### DIFF
--- a/src/hooks/useEventListener.test.tsx
+++ b/src/hooks/useEventListener.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, renderHook } from '@testing-library/react';
+import useEventListener from './useEventListener';
+import { act, useRef } from 'react';
+import * as utils from '../utils';
+
+describe('useEventListener', () => {
+  let handler: jest.Mock;
+
+  beforeEach(() => {
+    handler = jest.fn();
+  });
+
+  afterEach(() => {
+    cleanup();
+    jest.resetAllMocks();
+  });
+
+  const TestComponent = () => {
+    const ref = useRef<HTMLDivElement>(null);
+    useEventListener('click', handler, ref);
+    return <div ref={ref} data-testid="test-element"></div>;
+  };
+
+  test('이벤트 리스너가 document에 등록되고, 이벤트 발생 시 핸들러가 호출된다.', () => {
+    renderHook(() => useEventListener('click', handler, document));
+
+    act(() => {
+      fireEvent.click(document);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('이벤트 리스너가 HTMLElement에 등록되고, 이벤트 발생 시 핸들러가 호출된다.', () => {
+    const htmlElement = document.createElement('div');
+
+    document.body.appendChild(htmlElement);
+
+    renderHook(() => useEventListener('click', handler, htmlElement));
+
+    act(() => {
+      fireEvent.click(htmlElement);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    document.body.removeChild(htmlElement);
+  });
+
+  test('이벤트 리스너가 SVGElement에 등록되고, 이벤트 발생 시 핸들러가 호출된다.', () => {
+    const svgElement = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'svgElement'
+    );
+
+    document.body.appendChild(svgElement);
+
+    renderHook(() => useEventListener('click', handler, svgElement));
+
+    act(() => {
+      fireEvent.click(svgElement);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    document.body.removeChild(svgElement);
+  });
+
+  test('element가 null일때, window에 이벤트 리스너가 등록되어 이벤트 발생 시 핸들러가 호출된다.', () => {
+    renderHook(() => useEventListener('click', handler));
+
+    act(() => {
+      fireEvent.click(window);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('element가 RefObject일때, 이벤트 리스너가 등록되어 이벤트 발생 시 핸들러가 호출된다.', () => {
+    const { getByTestId } = render(<TestComponent />);
+
+    const element = getByTestId('test-element');
+
+    act(() => {
+      fireEvent.click(element);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('컴포넌트 언마운트 시 이벤트 리스너가 해제된다.', () => {
+    const { getByTestId, unmount } = render(<TestComponent />);
+
+    const element = getByTestId('test-element');
+
+    act(() => {
+      fireEvent.click(element);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      fireEvent.click(element);
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('isClient가 false일 때, 이벤트 리스너가 등록되지 않는다.', () => {
+    jest.spyOn(utils, 'isClient', 'get').mockReturnValue(false);
+    expect(utils.isClient).toBe(false);
+
+    renderHook(() => useEventListener('click', handler));
+
+    act(() => {
+      fireEvent.click(window);
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -15,6 +15,19 @@ type EventElement = {
   svgElement: RefObject<SVGElement> | SVGElement;
 };
 
+/**
+ * 특정 이벤트에 대한 이벤트 리스너를 추가하여, 이벤트 발생 시 핸들러를 실행하는 훅.
+ *
+ * @param {E} eventName - 추가할 이벤트의 이름.
+ * @param {(event: EventMap[K][E]) => void} handler - 이벤트 발생 시 호출되는 콜백 함수.
+ * @param {EventElement[K] | null} [element=window] - 이벤트를 추가할 대상 Element, 기본값은 window.
+ * @param {AddEventListenerOptions} [options] - 이벤트 리스너 기본 옵션.
+ *
+ * @description
+ * 지정된 이벤트가 발생할 때마다 제공된 핸들러를 호출합니다.
+ * 가능한 Element로 window, document, htmlElement, svgElement
+ */
+
 function useEventListener<
   K extends keyof EventMap,
   E extends keyof EventMap[K] & string,

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -2,22 +2,26 @@ import { useEffect } from 'react';
 
 // window event
 // dom elements
+// document
 // mediaqueries
 // with ref
 
-interface useEventListenerProps {
-  eventName: string;
-  handler: (e: Event) => void;
-  element?: Element | Window | null;
+interface useEventListenerProps<K extends keyof WindowEventMap> {
+  eventName: K;
+  handler: (event: WindowEventMap[K]) => void;
+  element?: Window | Document | Element | null;
 }
 
-function useEventListener(options: useEventListenerProps) {
-  const { eventName, handler, element = window } = options;
+function useEventListener<K extends keyof WindowEventMap>({
+  eventName,
+  handler,
+  element = window,
+}: useEventListenerProps<K>) {
   useEffect(() => {
     if (!element) return;
 
-    const eventListener = (e: Event) => {
-      handler(e);
+    const eventListener = (event: Event) => {
+      handler(event as WindowEventMap[K]);
     };
 
     element.addEventListener(eventName, eventListener);

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,27 +1,47 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
-// window event
-// dom elements
 // document
 // mediaqueries
 // with ref
 
-interface useEventListenerProps<K extends keyof WindowEventMap> {
+// isClient해줘야하나?
+
+type EventMap =
+  | WindowEventMap
+  | DocumentEventMap
+  | ElementEventMap
+  | SVGElementEventMap
+  | MediaQueryListEventMap;
+
+interface useEventListenerProps<K extends keyof EventMap> {
   eventName: K;
-  handler: (event: WindowEventMap[K]) => void;
-  element?: Window | Document | Element | null;
+  handler: (event: EventMap[K]) => void;
+  element?:
+    | Window
+    | Document
+    | HTMLElement
+    | HTMLElement
+    | SVGElement
+    | MediaQueryList
+    | null;
 }
 
-function useEventListener<K extends keyof WindowEventMap>({
+function useEventListener<K extends keyof EventMap>({
   eventName,
   handler,
   element = window,
 }: useEventListenerProps<K>) {
+  const savedHandler = useRef(handler);
+
+  useEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
   useEffect(() => {
     if (!element) return;
 
     const eventListener = (event: Event) => {
-      handler(event as WindowEventMap[K]);
+      handler(event as EventMap[K]);
     };
 
     element.addEventListener(eventName, eventListener);

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+// window event
+// dom elements
+// mediaqueries
+// with ref
+
+interface useEventListenerProps {
+  eventName: string;
+  handler: (e: Event) => void;
+  element?: Element | Window | null;
+}
+
+function useEventListener(options: useEventListenerProps) {
+  const { eventName, handler, element = window } = options;
+  useEffect(() => {
+    if (!element) return;
+
+    const eventListener = (e: Event) => {
+      handler(e);
+    };
+
+    element.addEventListener(eventName, eventListener);
+
+    return () => {
+      element.removeEventListener(eventName, eventListener);
+    };
+  }, [eventName, element, handler]);
+}
+
+export default useEventListener;

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -1,17 +1,14 @@
 import { useEffect, useRef } from 'react';
-
-// document
-// mediaqueries
-// with ref
+import { isClient } from '../utils';
 
 // isClient해줘야하나?
 
 type EventMap =
   | WindowEventMap
   | DocumentEventMap
-  | ElementEventMap
+  | HTMLElementEventMap
   | SVGElementEventMap
-  | MediaQueryListEventMap;
+  | ElementEventMap;
 
 interface useEventListenerProps<K extends keyof EventMap> {
   eventName: K;
@@ -20,16 +17,53 @@ interface useEventListenerProps<K extends keyof EventMap> {
     | Window
     | Document
     | HTMLElement
-    | HTMLElement
     | SVGElement
+    | Element
     | MediaQueryList
     | null;
+  options: AddEventListenerOptions;
 }
+
+function useEventListener<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: (event: WindowEventMap[K]) => void,
+  element?: Window | null,
+  options?: AddEventListenerOptions
+): void;
+
+function useEventListener<K extends keyof DocumentEventMap>(
+  eventName: K,
+  handler: (event: DocumentEventMap[K]) => void,
+  element?: Document,
+  options?: AddEventListenerOptions
+): void;
+
+function useEventListener<K extends keyof HTMLElementEventMap>(
+  eventName: K,
+  handler: (event: HTMLElementEventMap[K]) => void,
+  element?: HTMLElement,
+  options?: AddEventListenerOptions
+): void;
+
+function useEventListener<K extends keyof SVGElementEventMap>(
+  eventName: K,
+  handler: (event: SVGElementEventMap[K]) => void,
+  element?: SVGElement,
+  options?: AddEventListenerOptions
+): void;
+
+function useEventListener<K extends keyof ElementEventMap>(
+  eventName: K,
+  handler: (event: ElementEventMap[K]) => void,
+  element?: Element,
+  options?: AddEventListenerOptions
+): void;
 
 function useEventListener<K extends keyof EventMap>({
   eventName,
   handler,
   element = window,
+  options,
 }: useEventListenerProps<K>) {
   const savedHandler = useRef(handler);
 
@@ -38,18 +72,18 @@ function useEventListener<K extends keyof EventMap>({
   }, [handler]);
 
   useEffect(() => {
-    if (!element) return;
+    if (!element || !isClient) return;
 
     const eventListener = (event: Event) => {
       handler(event as EventMap[K]);
     };
 
-    element.addEventListener(eventName, eventListener);
+    element.addEventListener(eventName, eventListener, options);
 
     return () => {
-      element.removeEventListener(eventName, eventListener);
+      element.removeEventListener(eventName, eventListener, options);
     };
-  }, [eventName, element, handler]);
+  }, [eventName, element, handler, options]);
 }
 
 export default useEventListener;

--- a/src/hooks/useEventListener.ts
+++ b/src/hooks/useEventListener.ts
@@ -11,8 +11,8 @@ type EventMap = {
 type EventElement = {
   window: Window;
   document: Document;
-  htmlElement: RefObject<HTMLElement>;
-  svgElement: RefObject<SVGElement>;
+  htmlElement: RefObject<HTMLElement> | HTMLElement;
+  svgElement: RefObject<SVGElement> | SVGElement;
 };
 
 function useEventListener<


### PR DESCRIPTION
## 👾 Pull Request
<!-- PR 제목 예시: [티켓 번호] {작업명} {상태}-->

<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [useEventListener 신규](https://use-react-hooks.atlassian.net/browse/URH-50?atlOrigin=eyJpIjoiMzU0MmQ3MTIxYjA2NDEwOGFiNGE1MzRkN2FhM2ZiNGIiLCJwIjoiaiJ9)
<!-- (신규, 기능 업데이트, 버그 픽스, 리팩토링) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규

### 1️⃣ Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 특정 이벤트를 지정된 Element에 등록하고, 해당 이벤트가 발생할 때 지정된 callback을 호출하는 커스텀 훅
- 이벤트 리스너를 간편하게 관리할 수 있음

### 2️⃣ 변경 사항
<!-- 스펙이 변경되거나 내부 구조가 바뀐다면 작성해주세요. -->
- 없음

### 3️⃣ 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->

#### 기본적인 RefObject에 이벤트리스너를 지정할때
```ts
import { useRef } from 'react';
import useEventListener from './hooks/useEventListener';

function App() {
  const buttonRef = useRef<HTMLButtonElement>(null);

  const handleClick = () => {
    console.log('Button clicked!');
  };

  // RefObject에 대해 click이벤트를 설정
  useEventListener("click", handleClick, buttonRef);

  return (
    <div>
      <button ref={buttonRef}>Click</button>
    </div>
  );
}

export default App;
```

#### 그 외 다양한 경우들
1. 기본 window에 바로 설정
2. HTMLElement에 설정
3. EventListener 기본 option 활용(capture/once/passive)

```ts
import useEventListener from './hooks/useEventListener';

function App() {
  const handleResize = () => {
    console.log(window.innerWidth, window.innerHeight);
  };

  const handleClick = (event: MouseEvent) => {
    console.log(event.clientX, event.clientY);
  };

  const handleKeydown = (event: KeyboardEvent) => {
    console.log('Key pressed:', event.key);
  };

  // 1. Window에 대해 resize 이벤트를 설정
  useEventListener('resize', handleResize);

  // 2. HTMLElement에 대해 click 이벤트를 설정
  useEventListener('click', handleClick, document.getElementById('myButton')!);

  // 3. Document에 대해 keydown 이벤트를 설정 + once 옵션 사용
  useEventListener('keydown', handleKeydown, document, { once: true });

  return (
    <div>
      <button id="myButton">Click</button>
    </div>
  );
}

export default App;

```

### 4️⃣ 관련 문서 (선택 사항)
- https://developer.mozilla.org/ko/docs/Web/API/EventTarget/addEventListener


---
- 다른 레퍼런스를 참고하며 원래 오버로딩으로 구현되었었는데([216368d](https://github.com/frontend-opensource-project/use-react-hooks/pull/48/commits/216368d3eb43c05d212b7c96e4a26540a3eb49e2)) Generic으로 바꾸는 과정에서 최대한 노력은 했으나, 혹시 더 좋은 아이디어가 있으시다면 알려주시면 좋을 것 같습니다.