### PR TITLE
[URH-61] usePrefersColorScheme 신규

### DIFF
--- a/src/hooks/usePrefersColorScheme.ts
+++ b/src/hooks/usePrefersColorScheme.ts
@@ -1,0 +1,68 @@
+import { useSyncExternalStore } from 'react';
+import { Fn } from '../types';
+import { isClient } from '../utils';
+
+interface UsePrefersColorSchemeProps {
+  serverSnapshot?: ColorSchemeType;
+}
+
+type ColorSchemeType = 'dark' | 'light';
+
+const DEFAULT_COLOR_SCHEME: ColorSchemeType = 'light';
+
+const isServerSide = !isClient || typeof window.matchMedia !== 'function';
+
+/**
+ * 현재 사용자 컴퓨터의 다크 모드와 라이트 모드를 감지해서 반환
+ *
+ * @param {UsePrefersColorSchemeProps} SSR시 초기 색상 모드를 설정하기 위한 선택적 속성
+ * @returns {ColorSchemeType} 선호 색상 모드('dark' 또는 'light') 반환
+ */
+
+const usePrefersColorScheme = (
+  props: UsePrefersColorSchemeProps = {}
+): ColorSchemeType => {
+  const colorScheme = useSyncExternalStore(
+    subscribeToMediaQuery,
+    getMediaQuerySnapshot,
+    () => getServerSnapshot(props?.serverSnapshot)
+  );
+
+  return colorScheme;
+};
+
+export default usePrefersColorScheme;
+
+const subscribeToMediaQuery = (callback: Fn) => {
+  if (isServerSide) {
+    return () => {};
+  }
+
+  const darkColorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+  const handleChange = () => {
+    callback();
+  };
+
+  darkColorScheme.addEventListener('change', handleChange);
+
+  return () => {
+    darkColorScheme.removeEventListener('change', handleChange);
+  };
+};
+
+const getMediaQuerySnapshot = (): ColorSchemeType => {
+  if (isServerSide) {
+    return DEFAULT_COLOR_SCHEME;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+};
+
+const getServerSnapshot = (
+  serverSnapshot?: ColorSchemeType
+): ColorSchemeType => {
+  return serverSnapshot || DEFAULT_COLOR_SCHEME;
+};


### PR DESCRIPTION
## 👾 Pull Request
<!-- PR 제목 예시: [티켓 번호] {작업명} {상태}-->

<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [usePrefersColorScheme 신규](https://use-react-hooks.atlassian.net/browse/URH-61)
<!-- (신규, 기능 업데이트, 버그 픽스, 리팩토링) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규

### 1️⃣ Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 사용자의 운영 체제의 색상 설정을 감지하는 훅
- 다크모드일때는 'dark', 라이트모드일때는 'light'를 리턴

### 2️⃣ 변경 사항

### 3️⃣ 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->
```ts
import usePrefersColorScheme from './hooks/usePrefersColorScheme';

function App() {
  const colorScheme = usePrefersColorScheme();
  console.log('dark mode', colorScheme === 'dark');
  return (
    <div>
      <h1>USE-REACT-HOOKS</h1>
    </div>
  );
}

export default App;
```

### 4️⃣ 관련 문서 (선택 사항)
- https://ko.react.dev/reference/react/useSyncExternalStore
- https://developer.mozilla.org/ko/docs/Web/API/Window/matchMedia