### PR TITLE
[URH-55 ] useKeyCombination 신규

### DIFF
--- a/src/hooks/useKeyCombination.test.ts
+++ b/src/hooks/useKeyCombination.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import useKeyCombination from './useKeyCombination';
+
+describe('useKeyCombination', () => {
+  const shortcutKeys = ['MetaLeft', 'KeyK'];
+  const callback = jest.fn();
+
+  const pressKey = (code: string) =>
+    window.dispatchEvent(new KeyboardEvent('keydown', { code }));
+  const releaseKey = (code: string) =>
+    window.dispatchEvent(new KeyboardEvent('keyup', { code }));
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('지정된 키 조합이 눌렸을 때 콜백이 호출된다.', () => {
+    renderHook(() => useKeyCombination({ shortcutKeys, callback }));
+
+    act(() => {
+      pressKey('MetaLeft');
+      pressKey('KeyK');
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('키가 모두 눌리지 않으면 콜백이 호출되지 않는다.', () => {
+    renderHook(() =>
+      useKeyCombination({ shortcutKeys: shortcutKeys, callback })
+    );
+
+    act(() => {
+      pressKey('MetaLeft');
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('키가 떼어졌을 때 pressedKeyMap에서 제거된다.', () => {
+    renderHook(() =>
+      useKeyCombination({ shortcutKeys: shortcutKeys, callback })
+    );
+
+    act(() => {
+      // commend 키 눌렀다 떼기
+      pressKey('MetaLeft');
+
+      releaseKey('MetaLeft');
+    });
+
+    act(() => {
+      pressKey('KeyK');
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  test('한 조합키를 누른 상태에서 다른 키를 반복 입력 시 콜백이 호출된다', () => {
+    renderHook(() =>
+      useKeyCombination({ shortcutKeys: shortcutKeys, callback })
+    );
+
+    act(() => {
+      pressKey('MetaLeft');
+    });
+
+    act(() => {
+      pressKey('KeyK');
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      releaseKey('KeyK');
+    });
+
+    // MetaLeft 를 누르고 있는 상태에서 keyK를 떼면 콜백 함수가 호출되지 않음
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      pressKey('KeyK');
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test('isPrevent가 true일 때 기본 동작이 방지된다.', () => {
+    const preventDefaultSpy = jest.spyOn(Event.prototype, 'preventDefault');
+
+    renderHook(() =>
+      useKeyCombination({ shortcutKeys, callback, isPrevent: true })
+    );
+
+    act(() => {
+      pressKey('MetaLeft');
+      pressKey('KeyK');
+    });
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test('unmount 시 이벤트 리스너가 해제된다.', () => {
+    const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHook(() =>
+      useKeyCombination({ shortcutKeys, callback })
+    );
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(2); // keydown, keyup 각각 제거됨
+
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/src/hooks/useKeyCombination.ts
+++ b/src/hooks/useKeyCombination.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { Fn } from '../types';
+
+interface UseKeyCombination {
+  shortcutKeys: string[];
+  callback: Fn;
+  isPrevent?: boolean;
+}
+
+/**
+ * 지정된 키 조합이 눌렸을 때 콜백 함수를 호출하는 훅.
+ *
+ * @param {string[]} params.shortcutKeys - 키 조합을 나타내는 키 코드의 배열
+ * @param {Fn} params.callback - 키 조합이 감지되었을 때 실행할 콜백 함수
+ * @param {boolean} [params.isPrevent=false] - true로 설정하면 키 조합이 눌렸을 때 기본 동작 방지
+ *
+ * @description
+ * 이 훅은 지정된 키들이 모두 눌렸을 때 콜백 함수를 호출하며, 필요에 따라 기본 동작을 막을 수도 있습니다.
+ * 예를 들어, 'Ctrl + K' 키 조합을 감지하여 특정 작업을 실행하고자 할 때 사용할 수 있습니다.
+ */
+
+export const useKeyCombination = ({
+  shortcutKeys,
+  callback,
+  isPrevent = false,
+}: UseKeyCombination) => {
+  const shortcutKeysId = shortcutKeys.join();
+
+  useEffect(() => {
+    let pressedKeyMap: Record<string, boolean> = {};
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      pressedKeyMap[e.code] = true;
+      if (shortcutKeys.every((k) => pressedKeyMap[k])) {
+        if (isPrevent) e.preventDefault();
+        callback();
+      }
+    };
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      // macOS에서는 Meta 키가 눌린 상태에서 keyup 이벤트가 발생하지 않기에
+      // Meta가 떼어질 경우 다른 키들도 떼어진 것으로 간주
+      if (e.key === 'Meta') {
+        pressedKeyMap = {};
+        return;
+      }
+
+      pressedKeyMap[e.code] = false;
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shortcutKeysId, callback]);
+};
+
+export default useKeyCombination;


### PR DESCRIPTION
## 👾 Pull Request
<!-- PR 제목 예시: [티켓 번호] {작업명} {상태}-->

<!-- Jira 이슈를 참조해주세요. -->
- 티켓: [useKeyCombination 신규](https://use-react-hooks.atlassian.net/browse/URH-55)
<!-- (신규, 기능 업데이트, 버그 픽스, 리팩토링) 중에 어떤 상태의 PR인지 적어주세요! -->
- 상태: 신규 ~~(테스트 코드는 아직 작성 중입니다!)~~ 

### 1️⃣ Spec
<!-- 해당 함수가 어떤 기능을 하는지 작성해주세요. -->
- 지정된 키 조합이 눌렸을 때 콜백 함수를 호출하는 훅

### 2️⃣ 변경 사항
<!-- 스펙이 변경되거나 내부 구조가 바뀐다면 작성해주세요. -->
- 없음

### 3️⃣ 예시 코드
<!-- 예시 코드를 작성해서 어떻게 동작하는지 알게 해주세요! -->
```ts
import { useCallback, useRef, useState } from 'react';
import useKeyCombination from './hooks/useKeyCombination';

function App() {
  const [bold, setBold] = useState(false);
  const [isSave, setIsSave] = useState(false);
  const input = useRef<HTMLInputElement>(null);

  const toggleBold = useCallback(() => {
    setBold((state) => !state);
  }, [setBold]);

  const keyActions = {
    toggleBold: {
      shortcutKeys: ['ControlLeft', 'KeyB'],
      callback: toggleBold,
    },
    save: {
      shortcutKeys: ['MetaLeft', 'KeyS'],
      callback: useCallback(() => setIsSave((state) => !state), [setIsSave]),
      isPrevent: true,
    },
    search: {
      shortcutKeys: ['MetaLeft', 'KeyK'],
      callback: useCallback(() => input.current?.focus(), []),
    },
  };

  useKeyCombination(keyActions.toggleBold);
  useKeyCombination(keyActions.save);
  useKeyCombination(keyActions.search);

  return (
    <div>
      <input type="text" ref={input} placeholder="Press command + K" />
      <div>USE-REACT-HOOKS</div>
      <ul>
        <li style={{ fontWeight: bold ? 'bold' : 'normal' }}>
          command + B : Bold
        </li>
        <li>command + S: {isSave ? 'SAVE!' : 'Not saved yet'}</li>
      </ul>
    </div>
  );
}

export default App;

```
4️⃣ 관련 문서 (선택 사항)
- [Why does Javascript drop keyUp events when the metaKey is pressed on Mac browsers?](https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser)
- [Keyup event not firing when meta key is held (Mac OSX only?) - How to handle in javascript?](https://stackoverflow.com/questions/73412298/keyup-event-not-firing-when-meta-key-is-held-mac-osx-only-how-to-handle-in)
  - mac 환경인 경우, meta(command)키를 누른 상태에서는 keyup 이벤트가 발생하지 않습니다.